### PR TITLE
Change: Rename constants and a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import "github.com/progrhyme/go-lv"
 
 func main() {
 	name := "Bob"
-	// lv.SetLevel(lv.Debug) // for debug
+	// lv.SetLevel(lv.LDebug) // for debug
 	lv.Infof("Hello, %s!", name)
 }
 ```
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	logger := lv.New(os.Stderr, lv.Warning, log.LstdFlags)
+	logger := lv.New(os.Stderr, lv.LWarning, log.LstdFlags)
 	logger.Warnf("Something is wrong!")
 }
 ```

--- a/default.go
+++ b/default.go
@@ -4,10 +4,9 @@ import (
 	"io"
 	"log"
 	"os"
-	"strings"
 )
 
-const defaultLevel Level = Info
+const defaultLevel Level = LInfo
 
 var defaultLogger *Logger
 
@@ -34,47 +33,41 @@ func getDefaultLogger() *Logger {
 }
 
 // Printf always prints given data like fmt.Printf() with no prefix using package-level logger.
-func Printf(fmt string, v ...interface{}) {
-	getDefaultLogger().Printf(fmt, v...)
+func Printf(format string, v ...interface{}) {
+	getDefaultLogger().Printf(format, v...)
 }
 
 // Trace level logging using package-level logger.
-func Tracef(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[TRACE]", fmt}, " ")
-	getDefaultLogger().writef(Trace, fmt, v...)
+func Tracef(format string, v ...interface{}) {
+	getDefaultLogger().writef(LTrace, format, v...)
 }
 
 // Debug level logging using package-level logger.
-func Debugf(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[DEBUG]", fmt}, " ")
-	getDefaultLogger().writef(Debug, fmt, v...)
+func Debugf(format string, v ...interface{}) {
+	getDefaultLogger().writef(LDebug, format, v...)
 }
 
 // Info level logging using package-level logger.
-func Infof(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[INFO]", fmt}, " ")
-	getDefaultLogger().writef(Info, fmt, v...)
+func Infof(format string, v ...interface{}) {
+	getDefaultLogger().writef(LInfo, format, v...)
 }
 
 // Notice level logging using package-level logger.
-func Noticef(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[NOTICE]", fmt}, " ")
-	getDefaultLogger().writef(Notice, fmt, v...)
+func Noticef(format string, v ...interface{}) {
+	getDefaultLogger().writef(LNotice, format, v...)
 }
 
-// Warn level logging using package-level logger.
-func Warnf(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[WARN]", fmt}, " ")
-	getDefaultLogger().writef(Warning, fmt, v...)
+// Warning level logging using package-level logger.
+func Warnf(format string, v ...interface{}) {
+	getDefaultLogger().writef(LWarning, format, v...)
 }
 
 // Error level logging using package-level logger.
-func Errorf(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[ERROR]", fmt}, " ")
-	getDefaultLogger().writef(Error, fmt, v...)
+func Errorf(format string, v ...interface{}) {
+	getDefaultLogger().writef(LError, format, v...)
 }
 
 // Fatalf calls log.Fatalf() in standard package log through package-level logger.
-func Fatalf(fmt string, v ...interface{}) {
-	getDefaultLogger().Fatalf(fmt, v...)
+func Fatalf(format string, v ...interface{}) {
+	getDefaultLogger().Fatalf(format, v...)
 }

--- a/level.go
+++ b/level.go
@@ -1,8 +1,6 @@
 package lv
 
-import (
-	"strings"
-)
+import "strings"
 
 // Level represents filtering level.
 // Logger will filter out log data when called with lower level functions
@@ -17,7 +15,7 @@ const (
 	LError
 )
 
-var labelToLevel map[string]Level
+var strToLevel map[string]Level
 
 // String returns human-readable string of log level.
 //
@@ -44,23 +42,24 @@ func (lv Level) String() string {
 	}
 }
 
-// LabelToLevel returns Level by given label.
+// WordToLevel returns Level by given word. Argument word is case-insensitive.
 //
 // Examples:
 //
-//     lv.LabelToLevel("trace")     //=> lv.LTrace
-//     lv.LabelToLevel("warning")   //=> lv.LWarning
-//     lv.LabelToLevel("undefined") //=> 0
-func LabelToLevel(label string) Level {
-	if labelToLevel == nil {
-		initLabelToLevel()
+//     lv.WordToLevel("trace")     //=> lv.LTrace
+//     lv.WordToLevel("Info")      //=> lv.LInfo
+//     lv.WordToLevel("WARNING")   //=> lv.LWarning
+//     lv.WordToLevel("undefined") //=> 0
+func WordToLevel(word string) Level {
+	if strToLevel == nil {
+		initStringToLevel()
 	}
-	return labelToLevel[label]
+	return strToLevel[strings.ToUpper(word)]
 }
 
-func initLabelToLevel() {
-	labelToLevel = make(map[string]Level)
+func initStringToLevel() {
+	strToLevel = make(map[string]Level)
 	for i := LTrace; i.String() != "UNKNOWN"; i++ {
-		labelToLevel[strings.ToLower(i.String())] = i
+		strToLevel[i.String()] = i
 	}
 }

--- a/level.go
+++ b/level.go
@@ -9,12 +9,12 @@ import (
 type Level int
 
 const (
-	Trace Level = iota + 1
-	Debug
-	Info // Default level for package-level logger
-	Notice
-	Warning
-	Error
+	LTrace Level = iota + 1
+	LDebug
+	LInfo // Default level for package-level logger
+	LNotice
+	LWarning
+	LError
 )
 
 var labelToLevel map[string]Level
@@ -23,24 +23,24 @@ var labelToLevel map[string]Level
 //
 // Examples:
 //
-//     Debug.String()  //=> "Debug"
-//     Notice.String() //=> "Notice"
+//     LDebug.String()  //=> "DEBUG"
+//     LNotice.String() //=> "NOTICE"
 func (lv Level) String() string {
 	switch lv {
-	case Trace:
-		return "Trace"
-	case Debug:
-		return "Debug"
-	case Info:
-		return "Info"
-	case Notice:
-		return "Notice"
-	case Warning:
-		return "Warning"
-	case Error:
-		return "Error"
+	case LTrace:
+		return "TRACE"
+	case LDebug:
+		return "DEBUG"
+	case LInfo:
+		return "INFO"
+	case LNotice:
+		return "NOTICE"
+	case LWarning:
+		return "WARNING"
+	case LError:
+		return "ERROR"
 	default:
-		return "Unknown"
+		return "UNKNOWN"
 	}
 }
 
@@ -48,8 +48,8 @@ func (lv Level) String() string {
 //
 // Examples:
 //
-//     lv.LabelToLevel("trace")     //=> lv.Trace
-//     lv.LabelToLevel("warning")   //=> lv.Warning
+//     lv.LabelToLevel("trace")     //=> lv.LTrace
+//     lv.LabelToLevel("warning")   //=> lv.LWarning
 //     lv.LabelToLevel("undefined") //=> 0
 func LabelToLevel(label string) Level {
 	if labelToLevel == nil {
@@ -60,7 +60,7 @@ func LabelToLevel(label string) Level {
 
 func initLabelToLevel() {
 	labelToLevel = make(map[string]Level)
-	for i := Trace; i.String() != "Unknown"; i++ {
+	for i := LTrace; i.String() != "UNKNOWN"; i++ {
 		labelToLevel[strings.ToLower(i.String())] = i
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,9 +1,9 @@
 package lv
 
 import (
+	"fmt"
 	"io"
 	"log"
-	"strings"
 )
 
 // Logger embeds standard log.Logger.
@@ -15,57 +15,52 @@ type Logger struct {
 
 // New creates a new Logger. The out variable sets the destination to which log data will be written.
 // The prop argument defines the logging properties; it corresponds to 'flags' in 'log' package.
-func New(out io.Writer, lv Level, prop int) *Logger {
-	return &Logger{Logger: log.New(out, "", prop), Level: lv}
+func New(out io.Writer, l Level, prop int) *Logger {
+	return &Logger{Logger: log.New(out, "", prop), Level: l}
 }
 
-func (self *Logger) Printf(fmt string, v ...interface{}) {
-	self.Logger.Printf(fmt, v...)
+func (self *Logger) Printf(format string, v ...interface{}) {
+	self.Logger.Printf(format, v...)
 }
 
-func (self *Logger) writef(lv Level, fmt string, v ...interface{}) {
-	if lv >= self.Level {
-		self.Logger.Printf(fmt, v...)
+func (self *Logger) writef(l Level, format string, v ...interface{}) {
+	if l >= self.Level {
+		format := fmt.Sprintf("[%s] %s", l, format)
+		self.Logger.Printf(format, v...)
 	}
 }
 
 // Trace level logging.
-func (self *Logger) Tracef(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[TRACE]", fmt}, " ")
-	self.writef(Trace, fmt, v...)
+func (self *Logger) Tracef(format string, v ...interface{}) {
+	self.writef(LTrace, format, v...)
 }
 
 // Debug level logging.
-func (self *Logger) Debugf(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[DEBUG]", fmt}, " ")
-	self.writef(Debug, fmt, v...)
+func (self *Logger) Debugf(format string, v ...interface{}) {
+	self.writef(LDebug, format, v...)
 }
 
 // Info level logging.
-func (self *Logger) Infof(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[INFO]", fmt}, " ")
-	self.writef(Info, fmt, v...)
+func (self *Logger) Infof(format string, v ...interface{}) {
+	self.writef(LInfo, format, v...)
 }
 
 // Notice level logging.
-func (self *Logger) Noticef(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[NOTICE]", fmt}, " ")
-	self.writef(Notice, fmt, v...)
+func (self *Logger) Noticef(format string, v ...interface{}) {
+	self.writef(LNotice, format, v...)
 }
 
 // Warning level logging.
-func (self *Logger) Warnf(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[WARN]", fmt}, " ")
-	self.writef(Warning, fmt, v...)
+func (self *Logger) Warnf(format string, v ...interface{}) {
+	self.writef(LWarning, format, v...)
 }
 
 // Error level logging.
-func (self *Logger) Errorf(fmt string, v ...interface{}) {
-	fmt = strings.Join([]string{"[ERROR]", fmt}, " ")
-	self.writef(Error, fmt, v...)
+func (self *Logger) Errorf(format string, v ...interface{}) {
+	self.writef(LError, format, v...)
 }
 
 // Fatalf calls log.Fatalf() in standard package log.
-func (self *Logger) Fatalf(fmt string, v ...interface{}) {
-	self.Logger.Fatalf(fmt, v...)
+func (self *Logger) Fatalf(format string, v ...interface{}) {
+	self.Logger.Fatalf(format, v...)
 }

--- a/lv.go
+++ b/lv.go
@@ -10,7 +10,7 @@
 //
 //     func main() {
 //         name := "Bob"
-//         // lv.SetLevel(lv.Debug) // for debug
+//         // lv.SetLevel(lv.LDebug) // for debug
 //         lv.Infof("Hello, %s!", name)
 //     }
 //
@@ -23,7 +23,7 @@
 //     )
 //
 //     func main() {
-//         logger := lv.New(os.Stderr, lv.Warning, log.LstdFlags)
+//         logger := lv.New(os.Stderr, lv.LWarning, log.LstdFlags)
 //         logger.Warnf("Something is wrong!")
 //     }
 package lv

--- a/lv_test.go
+++ b/lv_test.go
@@ -34,13 +34,13 @@ func TestFilteredLogging(t *testing.T) {
 	}
 }
 
-func TestLabelToLevel(t *testing.T) {
+func TestWordToLevel(t *testing.T) {
 	label2Lv := map[string]Level{
-		"trace": LTrace, "warning": LWarning, "undef": 0,
+		"trace": LTrace, "Info": LInfo, "WARNING": LWarning, "undef": 0,
 	}
 	for label, lv := range label2Lv {
-		if LabelToLevel(label) != lv {
-			t.Errorf("Label unmatch. Got %s, Want %s", LabelToLevel(label), lv)
+		if WordToLevel(label) != lv {
+			t.Errorf("Label unmatch. Got %s, Want %s", WordToLevel(label), lv)
 		}
 	}
 }

--- a/lv_test.go
+++ b/lv_test.go
@@ -14,21 +14,21 @@ func TestLoggable(t *testing.T) {
 		t.Errorf("defaultLogger is not Loggable")
 	}
 	out := &strings.Builder{}
-	if !doLog(New(out, Info, 0)) {
+	if !doLog(New(out, LInfo, 0)) {
 		t.Errorf("New Logger is not Loggable")
 	}
 }
 
 func TestFilteredLogging(t *testing.T) {
 	out := &strings.Builder{}
-	Configure(out, Info, 0)
+	Configure(out, LNotice, 0)
 	msg := "blah blah blah."
-	Debugf(msg)
+	Infof(msg)
 	if out.String() != "" {
 		t.Errorf("Log is not filtered out. Got: %s, Want: %s", out.String(), "")
 	}
 	Warnf(msg)
-	want := fmt.Sprintf("[WARN] %s\n", msg)
+	want := fmt.Sprintf("[WARNING] %s\n", msg)
 	if out.String() != want {
 		t.Errorf("Log is printed. Got: %s, Want: %s", out.String(), want)
 	}
@@ -36,7 +36,7 @@ func TestFilteredLogging(t *testing.T) {
 
 func TestLabelToLevel(t *testing.T) {
 	label2Lv := map[string]Level{
-		"trace": Trace, "warning": Warning, "undef": 0,
+		"trace": LTrace, "warning": LWarning, "undef": 0,
 	}
 	for label, lv := range label2Lv {
 		if LabelToLevel(label) != lv {


### PR DESCRIPTION
Changes:

- Rename `Level` constants and their string representations. i.e. `Trace` -> `LTrace`, `"Trace"` -> `"TRACE"`
  - This is because the levels were ambiguous with functions and in order to reduce code redundancy.
- Rename func `LabelToLevel()` -> `WordToLevel()` and make the argument case-insensitive

These changes are for usability.