### PR TITLE
[change] Rename level LWarning -> LWarn; Add level LCritical

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	logger := lv.New(os.Stderr, lv.LWarning, log.LstdFlags)
+	logger := lv.New(os.Stderr, lv.LWarn, log.LstdFlags)
 	logger.Warnf("Something is wrong!")
 }
 ```

--- a/default.go
+++ b/default.go
@@ -59,12 +59,17 @@ func Noticef(format string, v ...interface{}) {
 
 // Warning level logging using package-level logger.
 func Warnf(format string, v ...interface{}) {
-	getDefaultLogger().writef(LWarning, format, v...)
+	getDefaultLogger().writef(LWarn, format, v...)
 }
 
 // Error level logging using package-level logger.
 func Errorf(format string, v ...interface{}) {
 	getDefaultLogger().writef(LError, format, v...)
+}
+
+// Critical level logging using package-level logger.
+func Criticalf(format string, v ...interface{}) {
+	getDefaultLogger().writef(LCritical, format, v...)
 }
 
 // Fatalf calls log.Fatalf() in standard package log through package-level logger.

--- a/level.go
+++ b/level.go
@@ -11,8 +11,9 @@ const (
 	LDebug
 	LInfo // Default level for package-level logger
 	LNotice
-	LWarning
+	LWarn
 	LError
+	LCritical
 )
 
 var strToLevel map[string]Level
@@ -33,10 +34,12 @@ func (lv Level) String() string {
 		return "INFO"
 	case LNotice:
 		return "NOTICE"
-	case LWarning:
-		return "WARNING"
+	case LWarn:
+		return "WARN"
 	case LError:
 		return "ERROR"
+	case LCritical:
+		return "CRITICAL"
 	default:
 		return "UNKNOWN"
 	}
@@ -48,7 +51,7 @@ func (lv Level) String() string {
 //
 //     lv.WordToLevel("trace")     //=> lv.LTrace
 //     lv.WordToLevel("Info")      //=> lv.LInfo
-//     lv.WordToLevel("WARNING")   //=> lv.LWarning
+//     lv.WordToLevel("WARN")      //=> lv.LWarn
 //     lv.WordToLevel("undefined") //=> 0
 func WordToLevel(word string) Level {
 	if strToLevel == nil {

--- a/logger.go
+++ b/logger.go
@@ -52,12 +52,17 @@ func (self *Logger) Noticef(format string, v ...interface{}) {
 
 // Warning level logging.
 func (self *Logger) Warnf(format string, v ...interface{}) {
-	self.writef(LWarning, format, v...)
+	self.writef(LWarn, format, v...)
 }
 
 // Error level logging.
 func (self *Logger) Errorf(format string, v ...interface{}) {
 	self.writef(LError, format, v...)
+}
+
+// Critical level logging.
+func (self *Logger) Criticalf(format string, v ...interface{}) {
+	self.writef(LCritical, format, v...)
 }
 
 // Fatalf calls log.Fatalf() in standard package log.

--- a/lv.go
+++ b/lv.go
@@ -23,7 +23,7 @@
 //     )
 //
 //     func main() {
-//         logger := lv.New(os.Stderr, lv.LWarning, log.LstdFlags)
+//         logger := lv.New(os.Stderr, lv.LWarn, log.LstdFlags)
 //         logger.Warnf("Something is wrong!")
 //     }
 package lv


### PR DESCRIPTION
These changes are made because ...

- Shorter name is prefered
- For general usecase

And there is no more plan to change interface for now.